### PR TITLE
Fix for scenario where version_label is empty

### DIFF
--- a/library/elasticbeanstalk_env.py
+++ b/library/elasticbeanstalk_env.py
@@ -121,7 +121,7 @@ def wait_for(ebs, app_name, env_name, wait_timeout, testfunc):
         time.sleep(15)
 
 def version_is_updated(version_label, env):
-    return env["VersionLabel"] == version_label
+    return version_label == ""  or env["VersionLabel"] == version_label
 
 def status_is_ready(env):
     return env["Status"] == "Ready"


### PR DESCRIPTION
version_label can be empty if you only want to update the config of the env and not the version deployed. In this case the wait_for was for ever looping.

Pulled from @fvant, already merged upstream.