### PR TITLE
Correctly wait for environments to terminate.

### DIFF
--- a/library/elasticbeanstalk_env.py
+++ b/library/elasticbeanstalk_env.py
@@ -148,10 +148,6 @@ def describe_env(ebs, app_name, env_name):
 
     if not isinstance(envs, list): return None
 
-    for env in envs:
-        if env.has_key("Status") and env["Status"] in ["Terminated","Terminating"]:
-            envs.remove(env)
-
     if len(envs) == 0: return None
 
     return envs if env_name is None else envs[0]


### PR DESCRIPTION
Fixes #9 

Previously when you terminated environments sometimes the module would fail out after calling terminate_environment()

I believe it was related to this section of code, effectively while the module was waiting for the environment to terminate, it would remove the environment from the list of environments to check if done yet, which would cause the key() checking to fail and a python error. 

```
fatal: [localhost]: FAILED! => {
    "changed": false, 
    "failed": true, 
    "invocation": {
        "module_args": {
            "app_name": "gitlab_ci_elasticbeanstalk", 
            "aws_access_key": null, 
            "aws_secret_key": null, 
            "cname_prefix": null, 
            "description": null, 
            "ec2_url": null, 
            "env_name": "terminate-88", 
            "option_settings": [], 
            "options_to_remove": [], 
            "profile": null, 
            "region": "us-west-2", 
            "security_token": null, 
            "solution_stack_name": null, 
            "state": "absent", 
            "tags": {}, 
            "template_name": null, 
            "tier_name": "WebServer", 
            "validate_certs": true, 
            "version_label": null, 
            "wait_timeout": 900
        }, 
        "module_name": "elasticbeanstalk_env"
    }, 
    "msg": "'NoneType' object has no attribute '__getitem__'"
}
```

Now the module properly waits for the terminated environment to finish terminating before exiting.